### PR TITLE
Support multiple sites via additional opts `site: :my_site` parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ chargebeex-*.tar
 .elixir_ls
 generate_doc.sh
 .env
+.lexical

--- a/config/test.exs
+++ b/config/test.exs
@@ -4,3 +4,8 @@ config :chargebeex,
   namespace: "test-namespace",
   api_key: "test_chargeebee_api_key",
   http_client: Chargebeex.HTTPClientMock
+
+config :chargebeex, :alternative,
+  namespace: "alternative-namespace",
+  api_key: "test_chargeebee_api_key",
+  http_client: Chargebeex.HTTPClientMock

--- a/lib/chargebeex.ex
+++ b/lib/chargebeex.ex
@@ -7,7 +7,8 @@ defmodule Chargebeex do
 
   ## Installation
 
-  The package can be installed by adding `chargebeex` to your list of dependencies in `mix.exs`:
+  The package can be installed by adding `chargebeex` to your list of
+  dependencies in `mix.exs`:
 
   ```elixir
   # mix.exs
@@ -20,14 +21,16 @@ defmodule Chargebeex do
 
   ## Configuration
 
-  Chargebeex can be configured using [Config](https://hexdocs.pm/elixir/1.12/Config.html) or environment variables.
+  Chargebeex can be configured using
+  [Config](https://hexdocs.pm/elixir/1.12/Config.html) or environment variables.
 
   ### Config
 
   ```elixir
   config :chargebeex,
-  namespace: "my-namespace",
-  api_key: "my-api-key"
+    namespace: "my-namespace",
+    api_key: "my-api-key"
+
   ```
 
   ### Environment variables
@@ -45,6 +48,25 @@ defmodule Chargebeex do
   {:ok, %Chargebeex.Customer{}} = Chargebeex.Customer.delete("foobar")
   ```
 
+  ### With Multiple Sites
+
+  To interact with multiple Chargebee sites, scope your Chargebee config to an
+  atom or module representing the site. For example, if you have a site called "my_site", you can do the following:
+
+  ```elixir
+  config :chargebeex, :my_site,
+    namespace: "my-other-namespace",
+    api_key: "my-second-api-key"
+  ```
+
+  And specify the site when calling the API:
+  ```elixir
+  {:ok, %Chargebeex.Customer{}} = Chargebeex.Customer.retrieve("foobar", site: :my_site)
+  {:ok, [%Chargebeex.Customer{}], [%Chargebeex.Customer{}]} = Chargebeex.Customer.list(site: :my_site)
+  {:ok, %Chargebeex.Customer{}} = Chargebeex.Customer.update("foobar", %{name: "updated"}, site: :my_site)
+  {:ok, %Chargebeex.Customer{}} = Chargebeex.Customer.delete("foobar", site: :my_site)
+  ```
+
   ### Custom Fields
 
   Chargebee provides a way to add user-specific fields for resources like
@@ -52,9 +74,9 @@ defmodule Chargebeex do
   Fields](https://www.chargebee.com/docs/2.0/custom_fields.html).
 
   These fields are prepended with the `cf_` prefix. These fields can be accessed
-  in the special `custom_fields` field of the structure. Please note Custom Fields
-  are only available for Customers, Subscriptions, Product Families, Plans,
-  Addons and Price Points.
+  in the special `custom_fields` field of the structure. Please note Custom
+  Fields are only available for Customers, Subscriptions, Product Families,
+  Plans, Addons and Price Points.
 
   #### Example:
 

--- a/lib/chargebeex/action.ex
+++ b/lib/chargebeex/action.ex
@@ -3,49 +3,49 @@ defmodule Chargebeex.Action do
   alias Chargebeex.Client
   alias Chargebeex.Builder
 
-  def retrieve(resource, id) do
+  def retrieve(resource, id, opts \\ []) do
     with path <- resource_path(resource, id),
-         {:ok, _status_code, _headers, content} <- Client.get(path),
+         {:ok, _status_code, _headers, content} <- Client.get(path, %{}, opts),
          builded <- Builder.build(content) do
       {:ok, put_resources(builded, resource)}
     end
   end
 
-  def list(resource, params \\ %{}) do
+  def list(resource, params \\ %{}, opts \\ []) do
     with path <- resource_base_path(resource),
-         {:ok, _status_code, _headers, content} <- Client.get(path, params),
+         {:ok, _status_code, _headers, content} <- Client.get(path, params, opts),
          {builded, metadata} <- Builder.build(content) do
       {:ok, Enum.map(builded, &put_resources(&1, resource)), metadata}
     end
   end
 
-  def create(resource, params) do
+  def create(resource, params, opts \\ []) do
     with path <- resource_base_path(resource),
-         {:ok, _status_code, _headers, content} <- Client.post(path, params),
+         {:ok, _status_code, _headers, content} <- Client.post(path, params, opts),
          builded <- Builder.build(content) do
       {:ok, put_resources(builded, resource)}
     end
   end
 
-  def update(resource, id, params) do
+  def update(resource, id, params, opts \\ []) do
     with path <- resource_path(resource, id),
-         {:ok, _status_code, _headers, content} <- Client.post(path, params),
+         {:ok, _status_code, _headers, content} <- Client.post(path, params, opts),
          builded <- Builder.build(content) do
       {:ok, put_resources(builded, resource)}
     end
   end
 
-  def delete(resource, id) do
+  def delete(resource, id, opts \\ []) do
     with path <- delete_path(resource, id),
-         {:ok, _status_code, _headers, content} <- Client.post(path),
+         {:ok, _status_code, _headers, content} <- Client.post(path, %{}, opts),
          builded <- Builder.build(content) do
       {:ok, put_resources(builded, resource)}
     end
   end
 
-  def generic_action(verb, resource, action, id, params \\ %{}) do
+  def generic_action(verb, resource, action, id, params \\ %{}, opts \\ []) do
     with path <- resource_path_generic(resource, id, action),
-         {:ok, _status_code, _headers, content} <- apply(Client, verb, [path, params]),
+         {:ok, _status_code, _headers, content} <- apply(Client, verb, [path, params, opts]),
          builded <- Builder.build(content) do
       {:ok, put_resources(builded, resource)}
     end

--- a/lib/chargebeex/client.ex
+++ b/lib/chargebeex/client.ex
@@ -1,17 +1,25 @@
 defmodule Chargebeex.Client do
   @moduledoc false
 
+  defp config(:default, path) do
+    Application.get_env(:chargebeex, path)
+  end
+
   defp config(site, path) do
     default = Application.get_env(:chargebeex, path)
 
-    case site do
-      :default ->
-        default
+    if site in [:host, :path, :namespace, :api_key] do
+      raise ArgumentError, "Site `#{inspect(site)}` is not permitted"
+    end
 
-      site ->
-        :chargebeex
-        |> Application.get_env(site)
-        |> Keyword.get(path, default)
+    case Application.get_env(:chargebeex, site) do
+      nil ->
+        raise ArgumentError, "Site `#{inspect(site)}` is not configured"
+
+      config ->
+        # Falls back to default config if the site config does not have the
+        # specified key. i.e. `:host` or `:path` is not configured
+        Keyword.get(config, path, default)
     end
   end
 

--- a/lib/chargebeex/customer/customer.ex
+++ b/lib/chargebeex/customer/customer.ex
@@ -307,57 +307,57 @@ defmodule Chargebeex.Customer do
           updated_at: 1648489755
           }}
   """
-  def delete(id), do: super(id)
+  def delete(id, opts \\ []), do: super(id, opts)
 
-  def update_payment_method(id, params) do
-    generic_action(:post, @resource, "update_payment_method", id, params)
+  def update_payment_method(id, params, opts \\ []) do
+    generic_action(:post, @resource, "update_payment_method", id, params, opts)
   end
 
-  def update_billing_info(id, params) do
-    generic_action(:post, @resource, "update_billing_info", id, params)
+  def update_billing_info(id, params, opts \\ []) do
+    generic_action(:post, @resource, "update_billing_info", id, params, opts)
   end
 
-  def assign_payment_role(id, params) do
-    generic_action(:post, @resource, "assign_payment_role", id, params)
+  def assign_payment_role(id, params, opts \\ []) do
+    generic_action(:post, @resource, "assign_payment_role", id, params, opts)
   end
 
-  def record_excess_payment(id, params) do
-    generic_action(:post, @resource, "record_excess_payment", id, params)
+  def record_excess_payment(id, params, opts \\ []) do
+    generic_action(:post, @resource, "record_excess_payment", id, params, opts)
   end
 
-  def collect_payment(id, params) do
-    generic_action(:post, @resource, "collect_payment", id, params)
+  def collect_payment(id, params, opts \\ []) do
+    generic_action(:post, @resource, "collect_payment", id, params, opts)
   end
 
-  def move(id, params) do
-    generic_action(:post, @resource, "move", id, params)
+  def move(id, params, opts \\ []) do
+    generic_action(:post, @resource, "move", id, params, opts)
   end
 
-  def change_billing_date(id, params) do
-    generic_action(:post, @resource, "change_billing_date", id, params)
+  def change_billing_date(id, params, opts \\ []) do
+    generic_action(:post, @resource, "change_billing_date", id, params, opts)
   end
 
-  def merge(id, params) do
-    generic_action(:post, @resource, "merge", id, params)
+  def merge(id, params, opts \\ []) do
+    generic_action(:post, @resource, "merge", id, params, opts)
   end
 
-  def clear_personal_data(id) do
-    generic_action(:post, @resource, "clear_personal_data", id)
+  def clear_personal_data(id, opts \\ []) do
+    generic_action(:post, @resource, "clear_personal_data", id, opts)
   end
 
-  def relationships(id, params) do
-    generic_action(:post, @resource, "relationships", id, params)
+  def relationships(id, params, opts \\ []) do
+    generic_action(:post, @resource, "relationships", id, params, opts)
   end
 
-  def delete_relationship(id) do
-    generic_action(:post, @resource, "delete_relationship", id)
+  def delete_relationship(id, opts \\ []) do
+    generic_action(:post, @resource, "delete_relationship", id, opts)
   end
 
-  def hierarchy(id, params) do
-    generic_action(:get, @resource, "hierarchy", id, params)
+  def hierarchy(id, params, opts \\ []) do
+    generic_action(:get, @resource, "hierarchy", id, params, opts)
   end
 
-  def update_hierarchy_settings(id, params) do
-    generic_action(:post, @resource, "update_hierarchy_settings", id, params)
+  def update_hierarchy_settings(id, params, opts \\ []) do
+    generic_action(:post, @resource, "update_hierarchy_settings", id, params, opts)
   end
 end

--- a/lib/chargebeex/hosted_page/hosted_page.ex
+++ b/lib/chargebeex/hosted_page/hosted_page.ex
@@ -29,9 +29,9 @@ defmodule Chargebeex.HostedPage do
 
   use ExConstructor, :build
 
-  def collect_now(params) do
+  def collect_now(params, opts \\ []) do
     with path <- Chargebeex.Action.resource_path_generic_without_id("hosted_page", "collect_now"),
-         {:ok, _status_code, _headers, content} <- Client.post(path, params),
+         {:ok, _status_code, _headers, content} <- Client.post(path, params, opts),
          builded <- Builder.build(content) do
       {:ok, Map.get(builded, "hosted_page")}
     end

--- a/lib/chargebeex/portal_session/portal_session.ex
+++ b/lib/chargebeex/portal_session/portal_session.ex
@@ -26,11 +26,12 @@ defmodule Chargebeex.PortalSession do
     Logs out the portal session. This should be called when customers logout of
     your application.
   """
-  def logout(id), do: generic_action(:post, @resource, "logout", id)
+  def logout(id, opts \\ []), do: generic_action(:post, @resource, "logout", id, opts)
 
   @doc """
     When an user is sent back to your return URL with session details, you
     should validate that information by calling this API.
   """
-  def activate(id, params), do: generic_action(:post, @resource, "activate", id, params)
+  def activate(id, params, opts \\ []),
+    do: generic_action(:post, @resource, "activate", id, params, opts)
 end

--- a/lib/chargebeex/quote/quote.ex
+++ b/lib/chargebeex/quote/quote.ex
@@ -70,20 +70,22 @@ defmodule Chargebeex.Quote do
     Changes the quote produced for creating a new subscription items
     (operation_type = `create_subscription_for_customer`)
   """
-  def edit_create_subscription_quote_for_items(id, params),
-    do: generic_action(:post, "quote", "edit_create_subscription_quote_for_items", id, params)
+  def edit_create_subscription_quote_for_items(id, params, opts \\ []),
+    do:
+      generic_action(:post, "quote", "edit_create_subscription_quote_for_items", id, params, opts)
 
   @doc """
     Changes the quote produced for updating the subscription items.
     (operation_type = `change_subscription`)
   """
-  def edit_update_subscription_quote_for_items(id, params),
-    do: generic_action(:post, "quote", "edit_update_subscription_quote_for_items", id, params)
+  def edit_update_subscription_quote_for_items(id, params, opts \\ []),
+    do:
+      generic_action(:post, "quote", "edit_update_subscription_quote_for_items", id, params, opts)
 
   @doc """
     Changes the quote produced for adding one-time charges and charge items.
     (operation_type = `onetime_invoice`)
   """
-  def edit_for_charge_items_and_charges(id, params),
-    do: generic_action(:post, "quote", "edit_for_charge_items_and_charges", id, params)
+  def edit_for_charge_items_and_charges(id, params, opts \\ []),
+    do: generic_action(:post, "quote", "edit_for_charge_items_and_charges", id, params, opts)
 end

--- a/lib/chargebeex/resource.ex
+++ b/lib/chargebeex/resource.ex
@@ -14,24 +14,38 @@ defmodule Chargebeex.Resource do
     Retrieve a resource
   """
   @callback retrieve(id :: String.t()) :: {:ok, struct()}
+  @callback retrieve(id :: String.t(), opts :: list()) :: {:ok, struct()}
   @doc """
     List a resource
   """
   @callback list(params :: map()) :: {:ok, list(), map()}
+  @callback list(params :: map(), opts :: list()) :: {:ok, list(), map()}
   @doc """
     Create a resource
   """
   @callback create(params :: map()) :: {:ok, struct()}
+  @callback create(params :: map(), opts :: list()) :: {:ok, struct()}
   @doc """
     Update a resource
   """
   @callback update(id :: String.t(), params :: map()) :: {:ok, struct()}
+  @callback update(id :: String.t(), params :: map(), opts :: list()) :: {:ok, struct()}
   @doc """
     Delete a resource
   """
   @callback delete(id :: String.t()) :: {:ok, struct()}
+  @callback delete(id :: String.t(), opts :: list()) :: {:ok, struct()}
 
-  @optional_callbacks retrieve: 1, list: 1, create: 1, update: 2, delete: 1
+  @optional_callbacks retrieve: 1,
+                      retrieve: 2,
+                      list: 1,
+                      list: 2,
+                      create: 1,
+                      create: 2,
+                      update: 2,
+                      update: 3,
+                      delete: 1,
+                      delete: 2
 
   defmacro __using__(opts) do
     only = Keyword.get(opts, :only, [:retrieve, :list, :create, :update, :delete])
@@ -41,39 +55,45 @@ defmodule Chargebeex.Resource do
       @resource Keyword.fetch!(opts, :resource)
       import Chargebeex.Action,
         only: [
-          retrieve: 2,
-          list: 2,
-          create: 2,
-          update: 3,
-          delete: 2,
+          retrieve: 3,
+          list: 3,
+          create: 3,
+          update: 4,
+          delete: 3,
           generic_action: 4,
-          generic_action: 5
+          generic_action: 5,
+          generic_action: 6
         ]
 
       if :retrieve in only do
-        def retrieve(id), do: retrieve(@resource, id)
+        def retrieve(id, opts \\ []), do: retrieve(@resource, id, opts)
         defoverridable retrieve: 1
+        defoverridable retrieve: 2
       end
 
       if :list in only do
-        def list(params \\ %{}), do: list(@resource, params)
+        def list(params \\ %{}, opts \\ []), do: list(@resource, params, opts)
         defoverridable list: 0
         defoverridable list: 1
+        defoverridable list: 2
       end
 
       if :create in only do
-        def create(params), do: create(@resource, params)
+        def create(params, opts \\ []), do: create(@resource, params, opts)
         defoverridable create: 1
+        defoverridable create: 2
       end
 
       if :update in only do
-        def update(id, params), do: update(@resource, id, params)
+        def update(id, params, opts \\ []), do: update(@resource, id, params, opts)
         defoverridable update: 2
+        defoverridable update: 3
       end
 
       if :delete in only do
-        def delete(id), do: delete(@resource, id)
+        def delete(id, opts \\ []), do: delete(@resource, id, opts)
         defoverridable delete: 1
+        defoverridable delete: 2
       end
     end
   end

--- a/test/chargebeex/client_test.exs
+++ b/test/chargebeex/client_test.exs
@@ -7,15 +7,22 @@ defmodule Chargebeex.ClientTest do
     test "should build simple params" do
       params = %{foo: "bar"}
 
-      assert Client.endpoint("/", params) ==
+      assert Client.endpoint(:default, "/", params) ==
                "https://test-namespace.chargebee.com/api/v2/?foo=bar"
     end
 
     test "should build nested params" do
       params = %{foo: %{bar: "baz"}}
 
-      assert Client.endpoint("/", params) ==
+      assert Client.endpoint(:default, "/", params) ==
                "https://test-namespace.chargebee.com/api/v2/?foo[bar]=baz"
+    end
+
+    test "when alternative site" do
+      params = %{foo: "bar"}
+
+      assert Client.endpoint(:alternative, "/", params) ==
+               "https://alternative-namespace.chargebee.com/api/v2/?foo=bar"
     end
   end
 end

--- a/test/chargebeex/client_test.exs
+++ b/test/chargebeex/client_test.exs
@@ -24,5 +24,17 @@ defmodule Chargebeex.ClientTest do
       assert Client.endpoint(:alternative, "/", params) ==
                "https://alternative-namespace.chargebee.com/api/v2/?foo=bar"
     end
+
+    test "when site name collides with application env configuration keys" do
+      assert_raise(ArgumentError, fn ->
+        Client.endpoint(:host, "/", %{})
+      end)
+    end
+
+    test "when site name  is not configured" do
+      assert_raise(ArgumentError, fn ->
+        Client.endpoint(:unkown, "/", %{})
+      end)
+    end
   end
 end


### PR DESCRIPTION
This PR adds a support for accessing multiple Chargebee sites from the same application. This is done with a new `opts` argument which takes a keyword list with the option `site` to specify a specific site.

Without this option the default `chargebeex` configuration is used. If `site: :my_site` is given in the opts argument configuration options are pulled from the application env `:chargebeex, :my_site`.

I opted against the implementations I proposed in #68 for the sake of simplicity and clarity. 

Resolves #68 