### PR TITLE
feat: allow to pass user details as headers

### DIFF
--- a/test/chargebeex/client_test.exs
+++ b/test/chargebeex/client_test.exs
@@ -1,6 +1,10 @@
 defmodule Chargebeex.ClientTest do
   use ExUnit.Case, async: true
 
+  import Hammox
+
+  setup :verify_on_exit!
+
   alias Chargebeex.Client
 
   describe "endpoint/1" do
@@ -35,6 +39,130 @@ defmodule Chargebeex.ClientTest do
       assert_raise(ArgumentError, fn ->
         Client.endpoint(:unkown, "/", %{})
       end)
+    end
+  end
+
+  describe "get" do
+    test "should allow to pass user_details" do
+      expect(
+        Chargebeex.HTTPClientMock,
+        :get,
+        fn url, body, headers ->
+          assert url == "https://test-namespace.chargebee.com/api/v2/customers"
+
+          assert headers == [
+                   {"chargebee-request-origin-ip", "127.0.0.1"},
+                   {"chargebee-request-origin-device", "Android"},
+                   {"chargebee-request-origin-user-encoded", "dXNlckB0ZXN0LmNvbQ=="},
+                   {"chargebee-request-origin-user", "user@test.com"},
+                   {"Authorization", "Basic dGVzdF9jaGFyZ2VlYmVlX2FwaV9rZXk6"}
+                 ]
+
+          assert body == ""
+
+          {:ok, 200, [], Jason.encode!(%{})}
+        end
+      )
+
+      assert {:ok, 200, [], %{}} =
+               Client.get("/customers", %{},
+                 user_ip: "127.0.0.1",
+                 user_device: "Android",
+                 user_email: "user@test.com",
+                 user_email_encoded: Base.encode64("user@test.com")
+               )
+    end
+
+    test "should not add headers that have a value as nil" do
+      expect(
+        Chargebeex.HTTPClientMock,
+        :get,
+        fn url, body, headers ->
+          assert url == "https://test-namespace.chargebee.com/api/v2/customers"
+
+          assert headers == [
+                   {"chargebee-request-origin-ip", "127.0.0.1"},
+                   {"chargebee-request-origin-user-encoded", "dXNlckB0ZXN0LmNvbQ=="},
+                   {"chargebee-request-origin-user", "user@test.com"},
+                   {"Authorization", "Basic dGVzdF9jaGFyZ2VlYmVlX2FwaV9rZXk6"}
+                 ]
+
+          assert body == ""
+
+          {:ok, 200, [], Jason.encode!(%{})}
+        end
+      )
+
+      assert {:ok, 200, [], %{}} =
+               Client.get("/customers", %{},
+                 user_ip: "127.0.0.1",
+                 user_device: nil,
+                 user_email: "user@test.com",
+                 user_email_encoded: Base.encode64("user@test.com")
+               )
+    end
+  end
+
+  describe "post" do
+    test "should allow to pass user_details" do
+      expect(
+        Chargebeex.HTTPClientMock,
+        :post,
+        fn url, body, headers ->
+          assert url == "https://test-namespace.chargebee.com/api/v2/customers"
+
+          assert headers == [
+                   {"chargebee-request-origin-ip", "127.0.0.1"},
+                   {"chargebee-request-origin-device", "Android"},
+                   {"chargebee-request-origin-user-encoded", "dXNlckB0ZXN0LmNvbQ=="},
+                   {"chargebee-request-origin-user", "user@test.com"},
+                   {"Authorization", "Basic dGVzdF9jaGFyZ2VlYmVlX2FwaV9rZXk6"},
+                   {"Content-Type", "application/x-www-form-urlencoded"}
+                 ]
+
+          assert body == ""
+
+          {:ok, 200, [], Jason.encode!(%{})}
+        end
+      )
+
+      assert {:ok, 200, [], %{}} =
+               Client.post("/customers", %{},
+                 user_ip: "127.0.0.1",
+                 user_device: "Android",
+                 user_email: "user@test.com",
+                 user_email_encoded: Base.encode64("user@test.com")
+               )
+    end
+
+    test "should not add headers that have a value as nil" do
+      expect(
+        Chargebeex.HTTPClientMock,
+        :post,
+        fn url, body, headers ->
+          assert url == "https://test-namespace.chargebee.com/api/v2/customers"
+
+          assert headers == [
+                   {"chargebee-request-origin-ip", "127.0.0.1"},
+                   {"chargebee-request-origin-user-encoded", "dXNlckB0ZXN0LmNvbQ=="},
+                   {"chargebee-request-origin-user", "user@test.com"},
+                   {"Authorization", "Basic dGVzdF9jaGFyZ2VlYmVlX2FwaV9rZXk6"},
+                   {"Content-Type", "application/x-www-form-urlencoded"}
+                 ]
+
+          assert body == ""
+
+          {:ok, 200, [], Jason.encode!(%{})}
+        end
+      )
+
+      assert {:ok, 200, [], %{}} =
+               Client.post("/customers", %{},
+                 user_ip: "127.0.0.1",
+                 user_device: nil,
+                 user_email: "user@test.com",
+                 user_email_encoded: Base.encode64("user@test.com")
+               )
     end
   end
 end


### PR DESCRIPTION
This is required for some endpoint (like create_card and create_bank_account) 😄 