### PR TITLE
feat: update subscription endpoint

### DIFF
--- a/lib/chargebeex/subscription/subscription.ex
+++ b/lib/chargebeex/subscription/subscription.ex
@@ -205,4 +205,15 @@ defmodule Chargebeex.Subscription do
       {:ok, Map.get(builded, @resource)}
     end
   end
+
+  def update_for_items(subscription_id, params, opts \\ []) do
+    Chargebeex.Action.generic_action(
+      :post,
+      @resource,
+      "update_for_items",
+      subscription_id,
+      params,
+      opts
+    )
+  end
 end

--- a/test/chargebeex/subscription_test.exs
+++ b/test/chargebeex/subscription_test.exs
@@ -98,4 +98,95 @@ defmodule Chargebeex.SubscriptionTest do
                })
     end
   end
+
+  describe "update_for_items" do
+    test "with bad authentication should fail" do
+      unauthorized = Common.unauthorized()
+
+      expect(
+        Chargebeex.HTTPClientMock,
+        :post,
+        fn url, data, headers ->
+          assert url ==
+                   "https://test-namespace.chargebee.com/api/v2/subscriptions/foobar/update_for_items"
+
+          assert headers == [
+                   {"Authorization", "Basic dGVzdF9jaGFyZ2VlYmVlX2FwaV9rZXk6"},
+                   {"Content-Type", "application/x-www-form-urlencoded"}
+                 ]
+
+          assert data == ""
+
+          {:ok, 401, [], Jason.encode!(unauthorized)}
+        end
+      )
+
+      assert {:error, 401, [], ^unauthorized} =
+               Chargebeex.Subscription.update_for_items("foobar", %{})
+    end
+
+    test "with invalid data should fail" do
+      bad_request = Common.bad_request()
+
+      expect(
+        Chargebeex.HTTPClientMock,
+        :post,
+        fn url, data, headers ->
+          assert url ==
+                   "https://test-namespace.chargebee.com/api/v2/subscriptions/foobar/update_for_items"
+
+          assert headers == [
+                   {"Authorization", "Basic dGVzdF9jaGFyZ2VlYmVlX2FwaV9rZXk6"},
+                   {"Content-Type", "application/x-www-form-urlencoded"}
+                 ]
+
+          assert data ==
+                   "subscription_items[item_price_id][0]=invalid_item_price_id&subscription_items[quantity][0]=1"
+
+          {:ok, 400, [], Jason.encode!(bad_request)}
+        end
+      )
+
+      assert {:error, 400, [], ^bad_request} =
+               Chargebeex.Subscription.update_for_items("foobar", %{
+                 subscription_items: [
+                   %{
+                     item_price_id: "invalid_item_price_id",
+                     quantity: 1
+                   }
+                 ]
+               })
+    end
+
+    test "with valid data should succeed" do
+      expect(
+        Chargebeex.HTTPClientMock,
+        :post,
+        fn url, data, headers ->
+          assert url ==
+                   "https://test-namespace.chargebee.com/api/v2/subscriptions/foobar/update_for_items"
+
+          assert headers == [
+                   {"Authorization", "Basic dGVzdF9jaGFyZ2VlYmVlX2FwaV9rZXk6"},
+                   {"Content-Type", "application/x-www-form-urlencoded"}
+                 ]
+
+          assert data ==
+                   "subscription_items[item_price_id][0]=item_price_id&subscription_items[quantity][0]=1"
+
+          {:ok, 200, [], Jason.encode!(%{customer: %{}, subscription: %{}})}
+        end
+      )
+
+      assert {:ok, %Subscription{}} =
+               Chargebeex.Subscription.update_for_items("foobar", %{
+                 subscription_items: [
+                   %{
+                     item_price_id: "item_price_id",
+                     quantity: 1
+                   }
+                 ]
+               })
+    end
+  end
 end


### PR DESCRIPTION
New endpoint support to update a given subscription. cf https://apidocs.chargebee.com/docs/api/subscriptions#update_subscription_for_items