### PR TITLE
feat: add `checkout_existing_for_items/2` to `HostedPage`

### DIFF
--- a/lib/chargebeex/hosted_page/hosted_page.ex
+++ b/lib/chargebeex/hosted_page/hosted_page.ex
@@ -1,9 +1,8 @@
 defmodule Chargebeex.HostedPage do
   use TypedStruct
 
-  use Chargebeex.Resource,
-    resource: "hosted_page",
-    only: [:retrieve, :list]
+  @resource "hosted_page"
+  use Chargebeex.Resource, resource: @resource, only: [:retrieve, :list]
 
   alias Chargebeex.Client
   alias Chargebeex.Builder
@@ -35,5 +34,24 @@ defmodule Chargebeex.HostedPage do
          builded <- Builder.build(content) do
       {:ok, Map.get(builded, "hosted_page")}
     end
+  end
+
+  @doc """
+  Creates a Chargebee hosted page to accept payment details from a customer
+  and checkout to update the subscription.
+
+  ## Examples
+
+      iex> Chargebeex.HostedPage.checkout_existing_for_items(%{
+        subscription: %{id: "subscription_id"},
+        layout: "in_app",
+        subscription_items: [
+          %{item_price_id: "item_price_id", quantity: 1}
+        ]
+      })
+      {:ok, %Chargebeex.HostedPage{}}
+  """
+  def checkout_existing_for_items(params, opts \\ []) do
+    generic_action_without_id(:post, @resource, "checkout_existing_for_items", params, opts)
   end
 end

--- a/lib/chargebeex/hosted_page/hosted_page.ex
+++ b/lib/chargebeex/hosted_page/hosted_page.ex
@@ -4,9 +4,6 @@ defmodule Chargebeex.HostedPage do
   @resource "hosted_page"
   use Chargebeex.Resource, resource: @resource, only: [:retrieve, :list]
 
-  alias Chargebeex.Client
-  alias Chargebeex.Builder
-
   typedstruct do
     field :id, String.t()
     field :type, String.t()
@@ -28,12 +25,23 @@ defmodule Chargebeex.HostedPage do
 
   use ExConstructor, :build
 
+  @doc """
+  Creates a Chargebee hosted page to collect due payments from a customer
+
+  ## Examples
+
+      iex> Chargebeex.HostedPage.collect_now(%{
+        customer: %{
+          id: "customer_id"
+        },
+        card: %{
+          gateway_account_id: "gateway_account_id"
+        }
+      })
+      {:ok, %Chargebeex.HostedPage{}}
+  """
   def collect_now(params, opts \\ []) do
-    with path <- Chargebeex.Action.resource_path_generic_without_id("hosted_page", "collect_now"),
-         {:ok, _status_code, _headers, content} <- Client.post(path, params, opts),
-         builded <- Builder.build(content) do
-      {:ok, Map.get(builded, "hosted_page")}
-    end
+    generic_action_without_id(:post, @resource, "collect_now", params, opts)
   end
 
   @doc """


### PR DESCRIPTION
- Adds support for Chargebee's `create_checkout_to_update_a_subscription` [endpoint](https://apidocs.chargebee.com/docs/api/hosted_pages?lang=curl#create_checkout_to_update_a_subscription);
- Borrows the function name `checkout_existing_for_items/3` from Chargebee's oficial [ruby library](https://github.com/chargebee/chargebee-ruby/blob/ccf4c65be1e3840c364f9e8e1a822b0caf99a78b/lib/chargebee/models/hosted_page.rb#L41);
- Improves and documents `HostedPage.collect_now/2` function.