### PR TITLE
feat: add `Usage`

### DIFF
--- a/lib/chargebeex/action.ex
+++ b/lib/chargebeex/action.ex
@@ -59,6 +59,21 @@ defmodule Chargebeex.Action do
     end
   end
 
+  def nested_generic_action_without_id(
+        verb,
+        nested_to,
+        resource,
+        action,
+        params \\ %{},
+        opts \\ []
+      ) do
+    with path <- nested_resource_path_generic_without_id(nested_to, action),
+         {:ok, _status_code, _headers, content} <- apply(Client, verb, [path, params, opts]),
+         builded <- Builder.build(content) do
+      {:ok, put_resources(builded, resource)}
+    end
+  end
+
   defp put_resources(builded, resource) do
     builded
     |> Map.get(resource, %{})

--- a/lib/chargebeex/builder.ex
+++ b/lib/chargebeex/builder.ex
@@ -14,7 +14,8 @@ defmodule Chargebeex.Builder do
     Item,
     ItemPrice,
     Quote,
-    QuotedSubscription
+    QuotedSubscription,
+    Usage
   }
 
   def build(%{"list" => resources, "next_offset" => next_offset}) do
@@ -45,6 +46,7 @@ defmodule Chargebeex.Builder do
   def build_resource(%{"item_price" => params}), do: ItemPrice.build(params)
   def build_resource(%{"quote" => params}), do: Quote.build(params)
   def build_resource(%{"quoted_subscription" => params}), do: QuotedSubscription.build(params)
+  def build_resource(%{"usage" => params}), do: Usage.build(params)
 
   def build_resource("subscription", params), do: Subscription.build(params)
   def build_resource("customer", params), do: Customer.build(params)
@@ -60,6 +62,7 @@ defmodule Chargebeex.Builder do
   def build_resource("item_price", params), do: ItemPrice.build(params)
   def build_resource("quote", params), do: Quote.build(params)
   def build_resource("quoted_subscription", params), do: QuotedSubscription.build(params)
+  def build_resource("usage", params), do: Usage.build(params)
 
   def build_resource(_resource, params), do: params
 end

--- a/lib/chargebeex/resource.ex
+++ b/lib/chargebeex/resource.ex
@@ -65,7 +65,10 @@ defmodule Chargebeex.Resource do
           generic_action: 6,
           generic_action_without_id: 3,
           generic_action_without_id: 4,
-          generic_action_without_id: 5
+          generic_action_without_id: 5,
+          nested_generic_action_without_id: 4,
+          nested_generic_action_without_id: 5,
+          nested_generic_action_without_id: 6
         ]
 
       if :retrieve in only do

--- a/lib/chargebeex/usage/usage.ex
+++ b/lib/chargebeex/usage/usage.ex
@@ -1,0 +1,89 @@
+defmodule Chargebeex.Usage do
+  use TypedStruct
+
+  @resource "usage"
+  use Chargebeex.Resource, resource: @resource, only: [:list]
+
+  @moduledoc """
+  Struct that represent a Chargebee's API usage resource.
+  """
+
+  @typedoc """
+  "admin_console" | "api" | "bulk_operation"
+  """
+  @type source :: String.t()
+
+  typedstruct do
+    field :id, String.t()
+    field :usage_date, String.t()
+    field :subscription_id, String.t()
+    field :item_price_id, String.t()
+    field :invoice_id, String.t()
+    field :line_item_id, String.t()
+    field :quantity, String.t()
+    field :source, source()
+    field :note, String.t()
+    field :resource_version, String.t()
+    field :updated_at, non_neg_integer()
+    field :created_at, non_neg_integer()
+  end
+
+  use ExConstructor, :build
+
+  @doc """
+  Allows to create a Usage
+
+  ## Examples
+
+      iex> Chargebeex.Usage.create(%{item_price_id: "item_eur_monthly", quantity: 42, usage_date: 1599817250})
+        {:ok, %Chargebeex.Usage{}}
+  """
+  def create(subscription_id, params, opts \\ []) do
+    nested_generic_action_without_id(
+      :post,
+      [subscription: subscription_id],
+      @resource,
+      "usages",
+      params,
+      opts
+    )
+  end
+
+  @doc """
+  Allows to retrieve a Usage
+
+  ## Examples
+
+      iex> Chargebeex.Usage.retrieve("e49e39cf-a406-4cc9-b14a-85476b3c3ebf", %{id: "a065d78c-a5a8-458b-85b6-e9295118d3bf"})
+        {:ok, %Chargebeex.Usage{}}
+  """
+  def retrieve(subscription_id, params, opts \\ []) do
+    nested_generic_action_without_id(
+      :get,
+      [subscription: subscription_id],
+      @resource,
+      "usages",
+      params,
+      opts
+    )
+  end
+
+  @doc """
+  Allows to delete a Usage
+
+  ## Examples
+
+      iex> Chargebeex.Usage.delete("e49e39cf-a406-4cc9-b14a-85476b3c3ebf", %{id: "a065d78c-a5a8-458b-85b6-e9295118d3bf"})
+        {:ok, %Chargebeex.Usage{}}
+  """
+  def delete(subscription_id, params, opts \\ []) do
+    nested_generic_action_without_id(
+      :post,
+      [subscription: subscription_id],
+      @resource,
+      "delete_usage",
+      params,
+      opts
+    )
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -81,7 +81,8 @@ defmodule Chargebeex.MixProject do
           Chargebeex.HostedPage,
           Chargebeex.ItemPrice,
           Chargebeex.PaymentSource,
-          Chargebeex.Item
+          Chargebeex.Item,
+          Chargebeex.Usage
         ]
       ]
     ]

--- a/test/chargebeex/builder/usage_test.exs
+++ b/test/chargebeex/builder/usage_test.exs
@@ -1,0 +1,40 @@
+defmodule Chargebeex.Builder.UsageTest do
+  use ExUnit.Case, async: true
+
+  alias Chargebeex.Builder
+  alias Chargebeex.Fixtures.Usage, as: UsageFixture
+  alias Chargebeex.Usage
+
+  describe "build/1" do
+    test "should build an usage" do
+      builded =
+        UsageFixture.retrieve()
+        |> Jason.decode!()
+        |> Builder.build()
+
+      assert %{"usage" => %Usage{}} = builded
+    end
+
+    test "should have the usage params" do
+      usage =
+        UsageFixture.retrieve()
+        |> Jason.decode!()
+        |> Builder.build()
+        |> Map.get("usage")
+
+      params = UsageFixture.usage_params() |> Jason.decode!()
+
+      assert usage.id == Map.get(params, "id")
+      assert usage.updated_at == Map.get(params, "updated_at")
+      assert usage.usage_date == Map.get(params, "usage_date")
+      assert usage.subscription_id == Map.get(params, "subscription_id")
+      assert usage.item_price_id == Map.get(params, "item_price_id")
+      assert usage.invoice_id == Map.get(params, "invoice_id")
+      assert usage.line_item_id == Map.get(params, "line_item_id")
+      assert usage.quantity == Map.get(params, "quantity")
+      assert usage.source == Map.get(params, "source")
+      assert usage.resource_version == Map.get(params, "resource_version")
+      assert usage.created_at == Map.get(params, "created_at")
+    end
+  end
+end

--- a/test/chargebeex/usage_test.exs
+++ b/test/chargebeex/usage_test.exs
@@ -1,0 +1,280 @@
+defmodule Chargebeex.UsageTest do
+  use ExUnit.Case, async: true
+
+  import Hammox
+
+  alias Chargebeex.Fixtures.Common
+  alias Chargebeex.Usage
+
+  setup :verify_on_exit!
+
+  describe "create" do
+    test "with bad authentication should fail" do
+      unauthorized = Common.unauthorized()
+
+      expect(
+        Chargebeex.HTTPClientMock,
+        :post,
+        fn url, data, headers ->
+          assert url ==
+                   "https://test-namespace.chargebee.com/api/v2/subscriptions/subscription_id/usages"
+
+          assert headers == [
+                   {"Authorization", "Basic dGVzdF9jaGFyZ2VlYmVlX2FwaV9rZXk6"},
+                   {"Content-Type", "application/x-www-form-urlencoded"}
+                 ]
+
+          assert data == ""
+
+          {:ok, 401, [], Jason.encode!(unauthorized)}
+        end
+      )
+
+      assert {:error, 401, [], ^unauthorized} = Usage.create("subscription_id", %{})
+    end
+
+    test "with invalid data should fail" do
+      bad_request = Common.bad_request()
+
+      expect(
+        Chargebeex.HTTPClientMock,
+        :post,
+        fn url, data, headers ->
+          assert url ==
+                   "https://test-namespace.chargebee.com/api/v2/subscriptions/subscription_id/usages"
+
+          assert headers == [
+                   {"Authorization", "Basic dGVzdF9jaGFyZ2VlYmVlX2FwaV9rZXk6"},
+                   {"Content-Type", "application/x-www-form-urlencoded"}
+                 ]
+
+          assert data == "invalid_attr=invalid"
+
+          {:ok, 400, [], Jason.encode!(bad_request)}
+        end
+      )
+
+      assert {:error, 400, [], ^bad_request} =
+               Usage.create("subscription_id", %{invalid_attr: "invalid"})
+    end
+
+    test "with valid data should succeed" do
+      expect(
+        Chargebeex.HTTPClientMock,
+        :post,
+        fn url, data, headers ->
+          assert url ==
+                   "https://test-namespace.chargebee.com/api/v2/subscriptions/subscription_id/usages"
+
+          assert headers == [
+                   {"Authorization", "Basic dGVzdF9jaGFyZ2VlYmVlX2FwaV9rZXk6"},
+                   {"Content-Type", "application/x-www-form-urlencoded"}
+                 ]
+
+          assert data == "quantity=42"
+
+          {:ok, 200, [], Jason.encode!(%{usage: %{}})}
+        end
+      )
+
+      assert {:ok, %Usage{}} = Chargebeex.Usage.create("subscription_id", %{quantity: "42"})
+    end
+  end
+
+  describe "retrieve" do
+    test "with bad authentication should fail" do
+      unauthorized = Common.unauthorized()
+
+      expect(
+        Chargebeex.HTTPClientMock,
+        :get,
+        fn url, body, headers ->
+          assert url ==
+                   "https://test-namespace.chargebee.com/api/v2/subscriptions/subscription_id/usages?id=foo"
+
+          assert headers == [{"Authorization", "Basic dGVzdF9jaGFyZ2VlYmVlX2FwaV9rZXk6"}]
+          assert body == ""
+
+          {:ok, 401, [], Jason.encode!(unauthorized)}
+        end
+      )
+
+      assert {:error, 401, [], ^unauthorized} = Usage.retrieve("subscription_id", %{id: "foo"})
+    end
+
+    test "with resource not found should fail" do
+      not_found = Common.not_found()
+
+      expect(
+        Chargebeex.HTTPClientMock,
+        :get,
+        fn url, body, headers ->
+          assert url ==
+                   "https://test-namespace.chargebee.com/api/v2/subscriptions/subscription_id/usages?id=foo"
+
+          assert headers == [{"Authorization", "Basic dGVzdF9jaGFyZ2VlYmVlX2FwaV9rZXk6"}]
+          assert body == ""
+
+          {:ok, 404, [], Jason.encode!(not_found)}
+        end
+      )
+
+      assert {:error, 404, [], ^not_found} = Usage.retrieve("subscription_id", %{id: "foo"})
+    end
+
+    test "with resource found should succeed" do
+      expect(
+        Chargebeex.HTTPClientMock,
+        :get,
+        fn url, body, headers ->
+          assert url ==
+                   "https://test-namespace.chargebee.com/api/v2/subscriptions/subscription_id/usages?id=foo"
+
+          assert headers == [{"Authorization", "Basic dGVzdF9jaGFyZ2VlYmVlX2FwaV9rZXk6"}]
+          assert body == ""
+
+          {:ok, 200, [], Jason.encode!(%{usage: %{}})}
+        end
+      )
+
+      assert {:ok, %Usage{}} = Usage.retrieve("subscription_id", %{id: "foo"})
+    end
+  end
+
+  describe "list" do
+    test "with bad authentication should fail" do
+      unauthorized = Common.unauthorized()
+
+      expect(
+        Chargebeex.HTTPClientMock,
+        :get,
+        fn url, body, headers ->
+          assert url ==
+                   "https://test-namespace.chargebee.com/api/v2/usages?subscription_id%5Bis%5D=foo"
+
+          assert headers == [{"Authorization", "Basic dGVzdF9jaGFyZ2VlYmVlX2FwaV9rZXk6"}]
+          assert body == ""
+
+          {:ok, 401, [], Jason.encode!(unauthorized)}
+        end
+      )
+
+      assert {:error, 401, [], ^unauthorized} = Usage.list(%{"subscription_id[is]" => "foo"})
+    end
+
+    test "with no param, no offset should succeed" do
+      expect(
+        Chargebeex.HTTPClientMock,
+        :get,
+        fn url, body, headers ->
+          assert url ==
+                   "https://test-namespace.chargebee.com/api/v2/usages?subscription_id%5Bis%5D=foo"
+
+          assert headers == [{"Authorization", "Basic dGVzdF9jaGFyZ2VlYmVlX2FwaV9rZXk6"}]
+          assert body == ""
+
+          {:ok, 200, [], Jason.encode!(%{list: [%{usage: %{}}, %{usage: %{}}]})}
+        end
+      )
+
+      assert {:ok, [%Usage{}, %Usage{}], %{"next_offset" => nil}} =
+               Usage.list(%{"subscription_id[is]" => "foo"})
+    end
+
+    test "with limit & offset params should succeed" do
+      expect(
+        Chargebeex.HTTPClientMock,
+        :get,
+        fn url, body, headers ->
+          assert url ==
+                   "https://test-namespace.chargebee.com/api/v2/usages?subscription_id%5Bis%5D=foo"
+
+          assert headers == [{"Authorization", "Basic dGVzdF9jaGFyZ2VlYmVlX2FwaV9rZXk6"}]
+          assert body == ""
+
+          result = %{
+            list: [%{usage: %{id: "foo"}}],
+            next_offset: "bar"
+          }
+
+          {:ok, 200, [], Jason.encode!(result)}
+        end
+      )
+
+      assert {:ok, [%Usage{}], %{"next_offset" => "bar"}} =
+               Usage.list(%{"subscription_id[is]" => "foo"}, limit: 1)
+    end
+  end
+
+  describe "delete" do
+    test "with bad authentication should fail" do
+      unauthorized = Common.unauthorized()
+
+      expect(
+        Chargebeex.HTTPClientMock,
+        :post,
+        fn url, body, headers ->
+          assert url ==
+                   "https://test-namespace.chargebee.com/api/v2/subscriptions/subscription_id/delete_usage"
+
+          assert headers == [
+                   {"Authorization", "Basic dGVzdF9jaGFyZ2VlYmVlX2FwaV9rZXk6"},
+                   {"Content-Type", "application/x-www-form-urlencoded"}
+                 ]
+
+          assert body == "id=foo"
+
+          {:ok, 401, [], Jason.encode!(unauthorized)}
+        end
+      )
+
+      assert {:error, 401, [], ^unauthorized} = Usage.delete("subscription_id", %{id: "foo"})
+    end
+
+    test "with resource not found should fail" do
+      not_found = Common.not_found()
+
+      expect(
+        Chargebeex.HTTPClientMock,
+        :post,
+        fn url, body, headers ->
+          assert url ==
+                   "https://test-namespace.chargebee.com/api/v2/subscriptions/subscription_id/delete_usage"
+
+          assert headers == [
+                   {"Authorization", "Basic dGVzdF9jaGFyZ2VlYmVlX2FwaV9rZXk6"},
+                   {"Content-Type", "application/x-www-form-urlencoded"}
+                 ]
+
+          assert body == "id=foo"
+
+          {:ok, 404, [], Jason.encode!(not_found)}
+        end
+      )
+
+      assert {:error, 404, [], ^not_found} = Usage.delete("subscription_id", %{id: "foo"})
+    end
+
+    test "with resource found should succeed" do
+      expect(
+        Chargebeex.HTTPClientMock,
+        :post,
+        fn url, body, headers ->
+          assert url ==
+                   "https://test-namespace.chargebee.com/api/v2/subscriptions/subscription_id/delete_usage"
+
+          assert headers == [
+                   {"Authorization", "Basic dGVzdF9jaGFyZ2VlYmVlX2FwaV9rZXk6"},
+                   {"Content-Type", "application/x-www-form-urlencoded"}
+                 ]
+
+          assert body == "id=foo"
+
+          {:ok, 200, [], Jason.encode!(%{usage: %{}})}
+        end
+      )
+
+      assert {:ok, %Usage{}} = Usage.delete("subscription_id", %{id: "foo"})
+    end
+  end
+end

--- a/test/support/fixtures/usage.ex
+++ b/test/support/fixtures/usage.ex
@@ -1,0 +1,39 @@
+defmodule Chargebeex.Fixtures.Usage do
+  def usage_params() do
+    """
+    {
+      "id": "a065d78c-a5a8-458b-85b6-e9295118d3bf",
+      "usage_date": 1599817250,
+      "subscription_id": "e49e39cf-a406-4cc9-b14a-85476b3c3ebf",
+      "item_price_id": "item_eur_monthly",
+      "invoice_id": "82d0478f-f424-43ae-b342-d8c516039200",
+      "line_item_id": "8b602549-a0f3-4ee7-8eb8-89200fa26ca4",
+      "quantity": 42,
+      "source": "api",
+      "resource_version": 1599817250735,
+      "updated_at": 1599817250,
+      "created_at": 1599817250
+    }
+    """
+  end
+
+  def retrieve() do
+    """
+    {
+      "usage": #{usage_params()}
+    }
+    """
+  end
+
+  def list() do
+    """
+    {
+      "list": [
+        #{retrieve()},
+        #{retrieve()}
+      ],
+      "next_offset": "1612890918000"
+    }
+    """
+  end
+end


### PR DESCRIPTION
- Adds support for Chargebee's usage [resource](https://apidocs.chargebee.com/docs/api/usages?lang=curl);
  - Adds support for Chargebee's usage create [endpoint](https://apidocs.chargebee.com/docs/api/usages?lang=curl#create_a_usage);
  - Adds support for Chargebee's usage retrieve [endpoint](https://apidocs.chargebee.com/docs/api/usages?lang=curl#retrieve_a_usage);
  - Adds support for Chargebee's usage delete [endpoint](https://apidocs.chargebee.com/docs/api/usages?lang=curl#delete_a_usage);
  - Adds support for Chargebee's usage list [endpoint](https://apidocs.chargebee.com/docs/api/usages?lang=curl#list_usages);