### PR TITLE
feat: add `AttachedItem`

### DIFF
--- a/lib/chargebeex/action.ex
+++ b/lib/chargebeex/action.ex
@@ -68,9 +68,11 @@ defmodule Chargebeex.Action do
         opts \\ []
       ) do
     with path <- nested_resource_path_generic_without_id(nested_to, action),
-         {:ok, _status_code, _headers, content} <- apply(Client, verb, [path, params, opts]),
-         builded <- Builder.build(content) do
-      {:ok, put_resources(builded, resource)}
+         {:ok, _status_code, _headers, content} <- apply(Client, verb, [path, params, opts]) do
+      case Builder.build(content) do
+        {builded, metadata} -> {:ok, Enum.map(builded, &put_resources(&1, resource)), metadata}
+        builded -> {:ok, put_resources(builded, resource)}
+      end
     end
   end
 

--- a/lib/chargebeex/attached_item/attached_item.ex
+++ b/lib/chargebeex/attached_item/attached_item.ex
@@ -1,0 +1,61 @@
+defmodule Chargebeex.AttachedItem do
+  use TypedStruct
+
+  @resource "attached_item"
+  use Chargebeex.Resource, resource: @resource, only: []
+
+  @moduledoc """
+  Struct that represent a Chargebee's API attached item resource.
+  """
+
+  @typedoc """
+  "recommended" | "mandatory" | "optional"
+  """
+  @type type :: String.t()
+
+  @typedoc """
+  "active" | "archived" | "deleted"
+  """
+  @type status :: String.t()
+
+  @typedoc """
+  "subscription_creation" | "subscription_trial_start" | "plan_activation" |
+  "subscription_activation" | "contract_termination" | "on_demand"
+  """
+  @type charge_event :: String.t()
+
+  @typedoc """
+  "web" | "app_store" | "play_store"
+  """
+  @type channel :: String.t()
+
+  typedstruct do
+    field :id, String.t()
+    field :parent_item_id, String.t()
+    field :item_id, String.t()
+    field :type, type()
+    field :status, status()
+    field :quantity, non_neg_integer()
+    field :quantity_in_decimals, non_neg_integer()
+    field :billing_cycles, non_neg_integer()
+    field :charge_on_event, charge_event()
+    field :charge_once, boolean()
+    field :resource_version, non_neg_integer()
+    field :channel, channel()
+    field :created_at, non_neg_integer()
+    field :updated_at, non_neg_integer()
+  end
+
+  use ExConstructor, :build
+
+  def list(item_id, params \\ %{}, opts \\ []) do
+    nested_generic_action_without_id(
+      :get,
+      [item: item_id],
+      @resource,
+      "attached_items",
+      params,
+      opts
+    )
+  end
+end

--- a/lib/chargebeex/attached_item/attached_item.ex
+++ b/lib/chargebeex/attached_item/attached_item.ex
@@ -48,6 +48,17 @@ defmodule Chargebeex.AttachedItem do
 
   use ExConstructor, :build
 
+  @doc """
+  Allows to list Attached Items
+
+  Available filters can be found here: https://apidocs.eu.chargebee.com/docs/api/attached_items#list_attached_items
+
+  ## Examples
+
+      iex> filters = %{limit: 2}
+      iex(2)> Chargebeex.AttachedItem.list(filters)
+      {:ok, [%Chargebeex.AttachedItem{...}, %Chargebeex.AttachedItem{...}], %{"next_offset" => nil}}
+  """
   def list(item_id, params \\ %{}, opts \\ []) do
     nested_generic_action_without_id(
       :get,

--- a/lib/chargebeex/builder.ex
+++ b/lib/chargebeex/builder.ex
@@ -1,6 +1,7 @@
 defmodule Chargebeex.Builder do
   @moduledoc false
   alias Chargebeex.{
+    AttachedItem,
     BankAccount,
     BillingAddress,
     Card,
@@ -47,6 +48,7 @@ defmodule Chargebeex.Builder do
   def build_resource(%{"quote" => params}), do: Quote.build(params)
   def build_resource(%{"quoted_subscription" => params}), do: QuotedSubscription.build(params)
   def build_resource(%{"usage" => params}), do: Usage.build(params)
+  def build_resource(%{"attached_item" => params}), do: AttachedItem.build(params)
 
   def build_resource("subscription", params), do: Subscription.build(params)
   def build_resource("customer", params), do: Customer.build(params)
@@ -63,6 +65,7 @@ defmodule Chargebeex.Builder do
   def build_resource("quote", params), do: Quote.build(params)
   def build_resource("quoted_subscription", params), do: QuotedSubscription.build(params)
   def build_resource("usage", params), do: Usage.build(params)
+  def build_resource("attached_item", params), do: AttachedItem.build(params)
 
   def build_resource(_resource, params), do: params
 end

--- a/lib/chargebeex/usage/usage.ex
+++ b/lib/chargebeex/usage/usage.ex
@@ -35,7 +35,7 @@ defmodule Chargebeex.Usage do
 
   ## Examples
 
-      iex> Chargebeex.Usage.create(%{item_price_id: "item_eur_monthly", quantity: 42, usage_date: 1599817250})
+      iex> Chargebeex.Usage.create("e49e39cf-a406-4cc9-b14a-85476b3c3ebf", %{item_price_id: "item_eur_monthly", quantity: 42, usage_date: 1599817250})
         {:ok, %Chargebeex.Usage{}}
   """
   def create(subscription_id, params, opts \\ []) do

--- a/mix.exs
+++ b/mix.exs
@@ -71,6 +71,7 @@ defmodule Chargebeex.MixProject do
           Chargebeex.Client.Hackney
         ],
         Resources: [
+          Chargebeex.AttachedItem,
           Chargebeex.Card,
           Chargebeex.Customer,
           Chargebeex.Event,

--- a/test/chargebeex/attached_item_test.exs
+++ b/test/chargebeex/attached_item_test.exs
@@ -1,0 +1,71 @@
+defmodule Chargebeex.AttachedItemTest do
+  use ExUnit.Case, async: true
+
+  import Hammox
+
+  alias Chargebeex.Fixtures.Common
+  alias Chargebeex.AttachedItem
+
+  setup :verify_on_exit!
+
+  describe "list" do
+    test "with bad authentication should fail" do
+      unauthorized = Common.unauthorized()
+
+      expect(
+        Chargebeex.HTTPClientMock,
+        :get,
+        fn url, body, headers ->
+          assert url == "https://test-namespace.chargebee.com/api/v2/items/item_id/attached_items"
+          assert headers == [{"Authorization", "Basic dGVzdF9jaGFyZ2VlYmVlX2FwaV9rZXk6"}]
+          assert body == ""
+
+          {:ok, 401, [], Jason.encode!(unauthorized)}
+        end
+      )
+
+      assert {:error, 401, [], ^unauthorized} = AttachedItem.list("item_id")
+    end
+
+    test "with no param, no offset should succeed" do
+      expect(
+        Chargebeex.HTTPClientMock,
+        :get,
+        fn url, body, headers ->
+          assert url == "https://test-namespace.chargebee.com/api/v2/items/item_id/attached_items"
+          assert headers == [{"Authorization", "Basic dGVzdF9jaGFyZ2VlYmVlX2FwaV9rZXk6"}]
+          assert body == ""
+
+          {:ok, 200, [], Jason.encode!(%{list: [%{attached_item: %{}}, %{attached_item: %{}}]})}
+        end
+      )
+
+      assert {:ok, [%AttachedItem{}, %AttachedItem{}], %{"next_offset" => nil}} =
+               AttachedItem.list("item_id")
+    end
+
+    test "with limit & offset params should succeed" do
+      expect(
+        Chargebeex.HTTPClientMock,
+        :get,
+        fn url, body, headers ->
+          assert url ==
+                   "https://test-namespace.chargebee.com/api/v2/items/item_id/attached_items?limit=1&type%5Bis%5D=mandatory"
+
+          assert headers == [{"Authorization", "Basic dGVzdF9jaGFyZ2VlYmVlX2FwaV9rZXk6"}]
+          assert body == ""
+
+          result = %{
+            list: [%{attached_item: %{id: "foo"}}],
+            next_offset: "bar"
+          }
+
+          {:ok, 200, [], Jason.encode!(result)}
+        end
+      )
+
+      assert {:ok, [%AttachedItem{}], %{"next_offset" => "bar"}} =
+               AttachedItem.list("item_id", %{"type[is]" => "mandatory", limit: 1})
+    end
+  end
+end

--- a/test/chargebeex/builder/attached_item_test.exs
+++ b/test/chargebeex/builder/attached_item_test.exs
@@ -1,0 +1,43 @@
+defmodule Chargebeex.Builder.AttachedItemTest do
+  use ExUnit.Case, async: true
+
+  alias Chargebeex.Builder
+  alias Chargebeex.Fixtures.AttachedItem, as: AttachedItemFixture
+  alias Chargebeex.AttachedItem
+
+  describe "build/1" do
+    test "should build an attached_item" do
+      builded =
+        AttachedItemFixture.retrieve()
+        |> Jason.decode!()
+        |> Builder.build()
+
+      assert %{"attached_item" => %AttachedItem{}} = builded
+    end
+
+    test "should have the attached_item params" do
+      attached_item =
+        AttachedItemFixture.retrieve()
+        |> Jason.decode!()
+        |> Builder.build()
+        |> Map.get("attached_item")
+
+      params = AttachedItemFixture.attached_item_params() |> Jason.decode!()
+
+      assert attached_item.id == Map.get(params, "id")
+      assert attached_item.parent_item_id == Map.get(params, "parent_item_id")
+      assert attached_item.item_id == Map.get(params, "item_id")
+      assert attached_item.type == Map.get(params, "type")
+      assert attached_item.status == Map.get(params, "status")
+      assert attached_item.quantity == Map.get(params, "quantity")
+      assert attached_item.quantity_in_decimals == Map.get(params, "quantity_in_decimals")
+      assert attached_item.billing_cycles == Map.get(params, "billing_cycles")
+      assert attached_item.charge_on_event == Map.get(params, "charge_on_event")
+      assert attached_item.charge_once == Map.get(params, "charge_once")
+      assert attached_item.resource_version == Map.get(params, "resource_version")
+      assert attached_item.channel == Map.get(params, "channel")
+      assert attached_item.updated_at == Map.get(params, "updated_at")
+      assert attached_item.created_at == Map.get(params, "created_at")
+    end
+  end
+end

--- a/test/chargebeex/subscription_test.exs
+++ b/test/chargebeex/subscription_test.exs
@@ -49,8 +49,11 @@ defmodule Chargebeex.SubscriptionTest do
                    {"Content-Type", "application/x-www-form-urlencoded"}
                  ]
 
-          assert data ==
-                   "subscription_items[quantity][0]=1&subscription_items[item_price_id][0]=invalid_item_price_id"
+          data = String.split(data, "&")
+
+          assert Enum.count(data) == 2
+          assert "subscription_items[quantity][0]=1" in data
+          assert "subscription_items[item_price_id][0]=invalid_item_price_id" in data
 
           {:ok, 400, [], Jason.encode!(bad_request)}
         end
@@ -80,8 +83,11 @@ defmodule Chargebeex.SubscriptionTest do
                    {"Content-Type", "application/x-www-form-urlencoded"}
                  ]
 
-          assert data ==
-                   "subscription_items[quantity][0]=1&subscription_items[item_price_id][0]=item_price_id"
+          data = String.split(data, "&")
+
+          assert Enum.count(data) == 2
+          assert "subscription_items[quantity][0]=1" in data
+          assert "subscription_items[item_price_id][0]=item_price_id" in data
 
           {:ok, 200, [], Jason.encode!(%{customer: %{}, subscription: %{}})}
         end
@@ -140,8 +146,11 @@ defmodule Chargebeex.SubscriptionTest do
                    {"Content-Type", "application/x-www-form-urlencoded"}
                  ]
 
-          assert data ==
-                   "subscription_items[quantity][0]=1&subscription_items[item_price_id][0]=invalid_item_price_id"
+          data = String.split(data, "&")
+
+          assert Enum.count(data) == 2
+          assert "subscription_items[quantity][0]=1" in data
+          assert "subscription_items[item_price_id][0]=invalid_item_price_id" in data
 
           {:ok, 400, [], Jason.encode!(bad_request)}
         end
@@ -171,8 +180,11 @@ defmodule Chargebeex.SubscriptionTest do
                    {"Content-Type", "application/x-www-form-urlencoded"}
                  ]
 
-          assert data ==
-                   "subscription_items[quantity][0]=1&subscription_items[item_price_id][0]=item_price_id"
+          data = String.split(data, "&")
+
+          assert Enum.count(data) == 2
+          assert "subscription_items[quantity][0]=1" in data
+          assert "subscription_items[item_price_id][0]=item_price_id" in data
 
           {:ok, 200, [], Jason.encode!(%{customer: %{}, subscription: %{}})}
         end

--- a/test/chargebeex/subscription_test.exs
+++ b/test/chargebeex/subscription_test.exs
@@ -50,7 +50,7 @@ defmodule Chargebeex.SubscriptionTest do
                  ]
 
           assert data ==
-                   "subscription_items[item_price_id][0]=invalid_item_price_id&subscription_items[quantity][0]=1"
+                   "subscription_items[quantity][0]=1&subscription_items[item_price_id][0]=invalid_item_price_id"
 
           {:ok, 400, [], Jason.encode!(bad_request)}
         end
@@ -81,7 +81,7 @@ defmodule Chargebeex.SubscriptionTest do
                  ]
 
           assert data ==
-                   "subscription_items[item_price_id][0]=item_price_id&subscription_items[quantity][0]=1"
+                   "subscription_items[quantity][0]=1&subscription_items[item_price_id][0]=item_price_id"
 
           {:ok, 200, [], Jason.encode!(%{customer: %{}, subscription: %{}})}
         end
@@ -141,7 +141,7 @@ defmodule Chargebeex.SubscriptionTest do
                  ]
 
           assert data ==
-                   "subscription_items[item_price_id][0]=invalid_item_price_id&subscription_items[quantity][0]=1"
+                   "subscription_items[quantity][0]=1&subscription_items[item_price_id][0]=invalid_item_price_id"
 
           {:ok, 400, [], Jason.encode!(bad_request)}
         end
@@ -172,7 +172,7 @@ defmodule Chargebeex.SubscriptionTest do
                  ]
 
           assert data ==
-                   "subscription_items[item_price_id][0]=item_price_id&subscription_items[quantity][0]=1"
+                   "subscription_items[quantity][0]=1&subscription_items[item_price_id][0]=item_price_id"
 
           {:ok, 200, [], Jason.encode!(%{customer: %{}, subscription: %{}})}
         end

--- a/test/support/fixtures/attached_item.ex
+++ b/test/support/fixtures/attached_item.ex
@@ -1,0 +1,42 @@
+defmodule Chargebeex.Fixtures.AttachedItem do
+  def attached_item_params() do
+    """
+    {
+      "id": "a065d78c-a5a8-458b-85b6-e9295118d3bf",
+      "parent_item_id": "16d8d51c-9d6f-47d0-9a50-7de1468e5131",
+      "item_id": "48591bc6-fc7b-442c-90c2-14758c16bc2f",
+      "type": "mandatory",
+      "status": "active",
+      "quantity": 1,
+      "quantity_in_decimal": 10,
+      "billing_cycles": 1,
+      "charge_on_event": "on_demand",
+      "charge_once": false,
+      "resource_version": 1599817250735,
+      "channel": "web",
+      "updated_at": 1599817250,
+      "created_at": 1599817250
+    }
+    """
+  end
+
+  def retrieve() do
+    """
+    {
+      "attached_item": #{attached_item_params()}
+    }
+    """
+  end
+
+  def list() do
+    """
+    {
+      "list": [
+        #{retrieve()},
+        #{retrieve()}
+      ],
+      "next_offset": "1612890918000"
+    }
+    """
+  end
+end


### PR DESCRIPTION
- Adds support for Chargebee's attached item [resource](https://apidocs.eu.chargebee.com/docs/api/attached_items);
  - Adds support for Chargebee's attached item list [endpoint](https://apidocs.eu.chargebee.com/docs/api/attached_items#list_attached_items).