### PR TITLE
feat: Add `CustomerEntitlement`

### DIFF
--- a/lib/chargebeex/builder.ex
+++ b/lib/chargebeex/builder.ex
@@ -6,6 +6,7 @@ defmodule Chargebeex.Builder do
     BillingAddress,
     Card,
     Customer,
+    CustomerEntitlement,
     Event,
     Invoice,
     HostedPage,
@@ -35,6 +36,7 @@ defmodule Chargebeex.Builder do
 
   def build_resource(%{"subscription" => params}), do: Subscription.build(params)
   def build_resource(%{"customer" => params}), do: Customer.build(params)
+  def build_resource(%{"customer_entitlement" => params}), do: CustomerEntitlement.build(params)
   def build_resource(%{"portal_session" => params}), do: PortalSession.build(params)
   def build_resource(%{"event" => params}), do: Event.build(params)
   def build_resource(%{"card" => params}), do: Card.build(params)
@@ -52,6 +54,7 @@ defmodule Chargebeex.Builder do
 
   def build_resource("subscription", params), do: Subscription.build(params)
   def build_resource("customer", params), do: Customer.build(params)
+  def build_resource("customer_entitlement", params), do: CustomerEntitlement.build(params)
   def build_resource("portal_session", params), do: PortalSession.build(params)
   def build_resource("event", params), do: Event.build(params)
   def build_resource("card", params), do: Card.build(params)

--- a/lib/chargebeex/customer_entitlement/customer_entitlement.ex
+++ b/lib/chargebeex/customer_entitlement/customer_entitlement.ex
@@ -1,0 +1,44 @@
+defmodule Chargebeex.CustomerEntitlement do
+  use TypedStruct
+
+  @resource "customer_entitlement"
+  use Chargebeex.Resource, resource: @resource, only: []
+
+  @moduledoc """
+  Struct that represent a Chargebee's API customer entitlement resource.
+  """
+
+  typedstruct do
+    field :customer_id, String.t()
+    field :subscription_id, String.t()
+    field :feature_id, String.t()
+    field :value, String.t()
+    field :name, String.t()
+    field :is_enabled, boolean()
+    field :object, String.t()
+  end
+
+  use ExConstructor, :build
+
+  @doc """
+  Allows to list Customer Entitlements
+
+  Available filters can be found here: https://apidocs.chargebee.com/docs/api/customer_entitlements#list_customer_entitlements
+
+  ## Examples
+
+      iex> filters = %{limit: 2}
+      iex(2)> Chargebeex.CustomerEntitlement.list(filters)
+      {:ok, [%Chargebeex.CustomerEntitlement{...}, %Chargebeex.CustomerEntitlement{...}], %{"next_offset" => nil}}
+  """
+  def list(customer_id, params \\ %{}, opts \\ []) do
+    nested_generic_action_without_id(
+      :get,
+      [customer: customer_id],
+      @resource,
+      "customer_entitlements",
+      params,
+      opts
+    )
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -74,6 +74,7 @@ defmodule Chargebeex.MixProject do
           Chargebeex.AttachedItem,
           Chargebeex.Card,
           Chargebeex.Customer,
+          Chargebeex.CustomerEntitlement,
           Chargebeex.Event,
           Chargebeex.Invoice,
           Chargebeex.PortalSession,

--- a/test/chargebeex/builder/customer_entitlement_test.exs
+++ b/test/chargebeex/builder/customer_entitlement_test.exs
@@ -1,0 +1,36 @@
+defmodule Chargebeex.Builder.CustomerEntitlementTest do
+  use ExUnit.Case, async: true
+
+  alias Chargebeex.Builder
+  alias Chargebeex.Fixtures.CustomerEntitlement, as: CustomerEntitlementFixture
+  alias Chargebeex.CustomerEntitlement
+
+  describe "build/1" do
+    test "should build an customer_entitlement" do
+      builded =
+        CustomerEntitlementFixture.retrieve()
+        |> Jason.decode!()
+        |> Builder.build()
+
+      assert %{"customer_entitlement" => %CustomerEntitlement{}} = builded
+    end
+
+    test "should have the customer_entitlement params" do
+      customer_entitlement =
+        CustomerEntitlementFixture.retrieve()
+        |> Jason.decode!()
+        |> Builder.build()
+        |> Map.get("customer_entitlement")
+
+      params = CustomerEntitlementFixture.customer_entitlement_params() |> Jason.decode!()
+
+      assert customer_entitlement.subscription_id == Map.get(params, "subscription_id")
+      assert customer_entitlement.customer_id == Map.get(params, "customer_id")
+      assert customer_entitlement.feature_id == Map.get(params, "feature_id")
+      assert customer_entitlement.value == Map.get(params, "value")
+      assert customer_entitlement.name == Map.get(params, "name")
+      assert customer_entitlement.is_enabled == Map.get(params, "is_enabled")
+      assert customer_entitlement.object == Map.get(params, "object")
+    end
+  end
+end

--- a/test/chargebeex/customer_entitlement_test.exs
+++ b/test/chargebeex/customer_entitlement_test.exs
@@ -1,0 +1,81 @@
+defmodule Chargebeex.CustomerEntitlementTest do
+  use ExUnit.Case, async: true
+
+  import Hammox
+
+  alias Chargebeex.Fixtures.Common
+  alias Chargebeex.CustomerEntitlement
+
+  setup :verify_on_exit!
+
+  describe "list" do
+    test "with bad authentication should fail" do
+      unauthorized = Common.unauthorized()
+
+      expect(
+        Chargebeex.HTTPClientMock,
+        :get,
+        fn url, body, headers ->
+          assert url ==
+                   "https://test-namespace.chargebee.com/api/v2/customers/customer_id/customer_entitlements"
+
+          assert headers == [{"Authorization", "Basic dGVzdF9jaGFyZ2VlYmVlX2FwaV9rZXk6"}]
+          assert body == ""
+
+          {:ok, 401, [], Jason.encode!(unauthorized)}
+        end
+      )
+
+      assert {:error, 401, [], ^unauthorized} = CustomerEntitlement.list("customer_id")
+    end
+
+    test "with no param, no offset should succeed" do
+      expect(
+        Chargebeex.HTTPClientMock,
+        :get,
+        fn url, body, headers ->
+          assert url ==
+                   "https://test-namespace.chargebee.com/api/v2/customers/customer_id/customer_entitlements"
+
+          assert headers == [{"Authorization", "Basic dGVzdF9jaGFyZ2VlYmVlX2FwaV9rZXk6"}]
+          assert body == ""
+
+          {:ok, 200, [],
+           Jason.encode!(%{
+             list: [%{customer_entitlement: %{}}, %{customer_entitlement: %{}}]
+           })}
+        end
+      )
+
+      assert {:ok, [%CustomerEntitlement{}, %CustomerEntitlement{}], %{"next_offset" => nil}} =
+               CustomerEntitlement.list("customer_id")
+    end
+
+    test "with limit & offset params should succeed" do
+      expect(
+        Chargebeex.HTTPClientMock,
+        :get,
+        fn url, body, headers ->
+          assert url ==
+                   "https://test-namespace.chargebee.com/api/v2/customers/customer_id/customer_entitlements?limit=1&feature_type%5Bis%5D=switch"
+
+          assert headers == [{"Authorization", "Basic dGVzdF9jaGFyZ2VlYmVlX2FwaV9rZXk6"}]
+          assert body == ""
+
+          result = %{
+            list: [%{customer_entitlement: %{customer_id: "customer_id"}}],
+            next_offset: "bar"
+          }
+
+          {:ok, 200, [], Jason.encode!(result)}
+        end
+      )
+
+      assert {:ok, [%CustomerEntitlement{}], %{"next_offset" => "bar"}} =
+               CustomerEntitlement.list("customer_id", %{
+                 "feature_type[is]" => "switch",
+                 limit: 1
+               })
+    end
+  end
+end

--- a/test/support/fixtures/customer_entitlement.ex
+++ b/test/support/fixtures/customer_entitlement.ex
@@ -1,0 +1,36 @@
+defmodule Chargebeex.Fixtures.CustomerEntitlement do
+  def customer_entitlement_params() do
+    """
+    {
+      "customer_id": "cus01",
+      "subscription_id": "sub123",
+      "feature_id": "licenses",
+      "feature_name": "Xero Integration",
+      "value": "60",
+      "name": "60 licenses",
+      "is_enabled": true,
+      "object": "customer_entitlement"
+    }
+    """
+  end
+
+  def retrieve() do
+    """
+    {
+      "customer_entitlement": #{customer_entitlement_params()}
+    }
+    """
+  end
+
+  def list() do
+    """
+    {
+      "list": [
+        #{retrieve()},
+        #{retrieve()}
+      ],
+      "next_offset": "1612890918000"
+    }
+    """
+  end
+end


### PR DESCRIPTION
- Adds support for Chargebee's customer entitlement [resource](https://apidocs.chargebee.com/docs/api/customer_entitlements);
   - Adds support for Chargebee's customer entitlement list [endpoint](https://apidocs.chargebee.com/docs/api/customer_entitlements#list_customer_entitlements).