### PR TITLE
Add SubscriptionEntitlement's set_availability support

### DIFF
--- a/lib/chargebeex/subscription_entitlement/subscription_entitlement.ex
+++ b/lib/chargebeex/subscription_entitlement/subscription_entitlement.ex
@@ -14,7 +14,7 @@ defmodule Chargebeex.SubscriptionEntitlement do
   @type feature_type :: String.t()
 
   @typedoc """
-  A single entitlement override map.
+  A single subscription entitlement map.
   """
   @type subscription_entitlement :: %{
           required(:feature_id) => String.t()

--- a/lib/chargebeex/subscription_entitlement/subscription_entitlement.ex
+++ b/lib/chargebeex/subscription_entitlement/subscription_entitlement.ex
@@ -94,10 +94,12 @@ defmodule Chargebeex.SubscriptionEntitlement do
        [%Chargebeex.SubscriptionEntitlement{...}], %{"next_offset" => nil}}
   """
   @spec set_availability(String.t(), set_availability_params(), keyword()) :: any()
+  def set_availability(subscription_id, params, opts \\ [])
+
   def set_availability(
         subscription_id,
         %{"is_enabled" => _is_enabled, "subscription_entitlements" => _entitlements} = params,
-        opts \\ []
+        opts
       ) do
     nested_generic_action_without_id(
       :post,
@@ -107,5 +109,11 @@ defmodule Chargebeex.SubscriptionEntitlement do
       params,
       opts
     )
+  end
+
+  def set_availability(_subscription_id, _params, _opts) do
+    raise ArgumentError, """
+    Invalid params provided to `set_availability`. Ensure that `params["is_enabled"]` and `params["subscription_entitlements"]` are provided.
+    """
   end
 end

--- a/lib/chargebeex/subscription_entitlement/subscription_entitlement.ex
+++ b/lib/chargebeex/subscription_entitlement/subscription_entitlement.ex
@@ -13,6 +13,22 @@ defmodule Chargebeex.SubscriptionEntitlement do
   """
   @type feature_type :: String.t()
 
+  @typedoc """
+  A single entitlement override map.
+  """
+  @type subscription_entitlement :: %{
+          required(:feature_id) => String.t()
+        }
+
+  @typedoc """
+  Parameters for the `set_availability` function.
+  """
+  @type set_availability_params :: %{
+          required(:is_enabled) => boolean(),
+          optional(:subscription_entitlements) => [subscription_entitlement()],
+          optional(any()) => any()
+        }
+
   typedstruct do
     field :subscription_id, String.t()
     field :feature_id, String.t()
@@ -44,6 +60,50 @@ defmodule Chargebeex.SubscriptionEntitlement do
       [subscription: subscription_id],
       @resource,
       "subscription_entitlements",
+      params,
+      opts
+    )
+  end
+
+  @doc """
+  Enables or disables specific subscription_entitlements for a subscription.
+
+
+  For more info, check the API doc: https://apidocs.eu.chargebee.com/docs/api/subscription_entitlements?lang=curl#enable/disable_subscription_entitlements
+
+  ## Examples
+  #
+      iex(1)> subscription_id = "BTLybZUInBGCXDMY"
+      "BTLybZUInBGCXDMY"
+      iex(2)> params = %{
+      ...(2)>   "is_enabled" => true,
+      ...(2)>   "subscription_entitlements" => [
+      ...(2)>     %{
+      ...(2)>       "feature_id" => "foo_feature"
+      ...(2)>     }
+      ...(2)>   ]
+      ...(2)> }
+      %{
+        "is_enabled" => true,
+        "subscription_entitlements" => [
+          %{"feature_id" => "foo_feature"}
+        ]
+      }
+      iex(3)> Chargebeex.SubscriptionEntitlement.set_availability(subscription_id, params)
+      {:ok,
+       [%Chargebeex.SubscriptionEntitlement{...}], %{"next_offset" => nil}}
+  """
+  @spec set_availability(String.t(), set_availability_params(), keyword()) :: any()
+  def set_availability(
+        subscription_id,
+        %{"is_enabled" => _is_enabled, "subscription_entitlements" => _entitlements} = params,
+        opts \\ []
+      ) do
+    nested_generic_action_without_id(
+      :post,
+      [subscription: subscription_id],
+      @resource,
+      "subscription_entitlements/set_availability",
       params,
       opts
     )

--- a/test/chargebeex/subscription_entitlement_test.exs
+++ b/test/chargebeex/subscription_entitlement_test.exs
@@ -5,6 +5,7 @@ defmodule Chargebeex.SubscriptionEntitlementTest do
 
   alias Chargebeex.Fixtures.Common
   alias Chargebeex.SubscriptionEntitlement
+  alias Chargebeex.Fixtures.SubscriptionEntitlement, as: SubscriptionEntitlementFixture
 
   setup :verify_on_exit!
 
@@ -77,6 +78,74 @@ defmodule Chargebeex.SubscriptionEntitlementTest do
                  "feature_type[is]" => "switch",
                  limit: 1
                })
+    end
+  end
+
+  describe "set_availability/3" do
+    test "with bad authentication should fail" do
+      unauthorized = Common.unauthorized()
+
+      expect(
+        Chargebeex.HTTPClientMock,
+        :post,
+        fn url, body, headers ->
+          assert url ==
+                   "https://test-namespace.chargebee.com/api/v2/subscriptions/subscription_id/subscription_entitlements/set_availability"
+
+          assert headers == [
+                   {"Authorization", "Basic dGVzdF9jaGFyZ2VlYmVlX2FwaV9rZXk6"},
+                   {"Content-Type", "application/x-www-form-urlencoded"}
+                 ]
+
+          assert body == "is_enabled=true"
+
+          {:ok, 401, [], Jason.encode!(unauthorized)}
+        end
+      )
+
+      params = %{
+        "is_enabled" => true,
+        "subscription_entitlements" => []
+      }
+
+      assert {:error, 401, [], ^unauthorized} =
+               SubscriptionEntitlement.set_availability("subscription_id", params)
+    end
+
+    test "with valid data should succeed" do
+      expect(
+        Chargebeex.HTTPClientMock,
+        :post,
+        fn url, body, headers ->
+          assert url ==
+                   "https://test-namespace.chargebee.com/api/v2/subscriptions/subscription_id/subscription_entitlements/set_availability"
+
+          assert headers == [
+                   {"Authorization", "Basic dGVzdF9jaGFyZ2VlYmVlX2FwaV9rZXk6"},
+                   {"Content-Type", "application/x-www-form-urlencoded"}
+                 ]
+
+          assert body == "is_enabled=true&subscription_entitlements[feature_id][0]=foo_feature_id"
+
+          {:ok, 200, [], SubscriptionEntitlementFixture.list()}
+        end
+      )
+
+      subscription_id = "BTLybZUInBGCXDMY"
+
+      params = %{
+        "is_enabled" => true,
+        "subscription_entitlements" => [
+          %{
+            "feature_id" => "shore-bm-customer-feedback"
+          }
+        ]
+      }
+
+      Chargebeex.SubscriptionEntitlement.set_availability(subscription_id, params)
+
+      assert {:ok, [%SubscriptionEntitlement{}], %{"next_offset" => _}} =
+               SubscriptionEntitlement.set_availability(subscription_id, params)
     end
   end
 end

--- a/test/chargebeex/subscription_entitlement_test.exs
+++ b/test/chargebeex/subscription_entitlement_test.exs
@@ -131,21 +131,29 @@ defmodule Chargebeex.SubscriptionEntitlementTest do
         end
       )
 
-      subscription_id = "BTLybZUInBGCXDMY"
+      subscription_id = "subscription_id"
 
       params = %{
         "is_enabled" => true,
         "subscription_entitlements" => [
           %{
-            "feature_id" => "shore-bm-customer-feedback"
+            "feature_id" => "foo_feature_id"
           }
         ]
       }
 
-      Chargebeex.SubscriptionEntitlement.set_availability(subscription_id, params)
-
       assert {:ok, [%SubscriptionEntitlement{}], %{"next_offset" => _}} =
                SubscriptionEntitlement.set_availability(subscription_id, params)
+    end
+
+    test "with invalid params should raise error" do
+      subscription_id = "subscription_id"
+
+      invalid_params = %{}
+
+      assert_raise ArgumentError, ~r/Invalid params provided to `set_availability`/, fn ->
+        SubscriptionEntitlement.set_availability(subscription_id, invalid_params)
+      end
     end
   end
 end

--- a/test/support/fixtures/subscription_entitlement.ex
+++ b/test/support/fixtures/subscription_entitlement.ex
@@ -27,7 +27,6 @@ defmodule Chargebeex.Fixtures.SubscriptionEntitlement do
     """
     {
       "list": [
-        #{retrieve()},
         #{retrieve()}
       ],
       "next_offset": "1612890918000"


### PR DESCRIPTION
## Context

This PR adds support to SubscriptionEntitlement's [set_availability action support](https://apidocs.eu.chargebee.com/docs/api/subscription_entitlements?lang=curl#enable/disable_subscription_entitlements).