### PR TITLE
feat: add `delete/1` to `Subscription`

### DIFF
--- a/lib/chargebeex/subscription/subscription.ex
+++ b/lib/chargebeex/subscription/subscription.ex
@@ -2,7 +2,7 @@ defmodule Chargebeex.Subscription do
   use TypedStruct
 
   @resource "subscription"
-  use Chargebeex.Resource, resource: @resource, only: [:list, :retrieve, :update]
+  use Chargebeex.Resource, resource: @resource, only: [:list, :retrieve, :update, :delete]
 
   @typedoc """
   "future" | "in_trial" | "active" | "non_renewing" | "paused" | "cancelled"


### PR DESCRIPTION
Adds support for Chargebee's delete_a_subscription [endpoint](https://apidocs.chargebee.com/docs/api/subscriptions?lang=curl#delete_a_subscription);