### PR TITLE
feat: add OpenTelemetry support with default no-op adapter

### DIFF
--- a/lib/chargebeex/open_telemetry/default.ex
+++ b/lib/chargebeex/open_telemetry/default.ex
@@ -1,0 +1,16 @@
+defmodule Chargebeex.OpenTelemetry.Default do
+  @moduledoc """
+  Default no-op implementation of the OpenTelemetry behaviour.
+  """
+
+  @behaviour Chargebeex.OpenTelemetry.OpenTelemetryBehaviour
+
+  @impl true
+  def with_span(_name, _attributes, fun), do: fun.()
+
+  @impl true
+  def ok(_status_code), do: true
+
+  @impl true
+  def error(_status_code, _body), do: true
+end

--- a/lib/chargebeex/open_telemetry/open_telemetry_behavior.ex
+++ b/lib/chargebeex/open_telemetry/open_telemetry_behavior.ex
@@ -1,0 +1,12 @@
+defmodule Chargebeex.OpenTelemetry.OpenTelemetryBehaviour do
+  @moduledoc """
+  Define the callbacks for an adapter to implement OpenTelemetry.
+  """
+
+  @callback with_span(name :: String.t(), attributes :: map(), body :: function()) ::
+              {:ok, integer(), list(), any()} | {:error, integer(), list(), any()}
+
+  @callback ok(status_code :: integer()) :: boolean()
+
+  @callback error(status_code :: integer(), body :: map()) :: boolean()
+end


### PR DESCRIPTION
This pull request introduces OpenTelemetry integration into the `Chargebeex` library, enabling users to implement custom span instrumentation for tracing and monitoring. It includes a default no-op implementation and allows configuration of custom adapters. Additionally, OpenTelemetry spans are integrated into the `Chargebeex.Client` module for HTTP request tracing.

### OpenTelemetry Integration

* **Documentation Update**: Added a new section in the `README.md` explaining OpenTelemetry integration, including default behavior, custom implementation examples, configuration, and usage.
* **Default Implementation**: Implemented a no-op module `Chargebeex.OpenTelemetry.Default` that adheres to the OpenTelemetry behavior, serving as the default adapter.
* **Behavior Definition**: Defined the `Chargebeex.OpenTelemetry.OpenTelemetryBehaviour` module, specifying the required callbacks for custom OpenTelemetry adapters.

### Client Module Enhancements

* **Tracing Integration**: Integrated OpenTelemetry span creation into the `Chargebeex.Client` module for `get` and `post` methods, enabling automatic tracing of HTTP requests.
* **Adapter Configuration**: Added a private function `otel_adapter/0` in `Chargebeex.Client` to fetch the configured OpenTelemetry adapter, defaulting to `Chargebeex.OpenTelemetry.Default`.