### PR TITLE
feat: add :telemetry support with HTTP client events

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,27 @@ fields can be accessed in the `resources` field of the structure.
   }
 ```
 
+### Telemetry Integration
+
+Chargebeex now supports `:telemetry`, allowing users to instrument and monitor API calls using telemetry events. This enables integration with various observability tools.
+
+#### Telemetry Events
+
+Chargebeex emits the following telemetry events for each API request:
+
+- `[:chargebeex, :request, :start]`: Emitted when an API request starts.
+- `[:chargebeex, :request, :stop]`: Emitted when an API request completes.
+
+When making API calls, telemetry events will automatically be emitted:
+
+```elixir
+Chargebeex.Client.get("/customers")
+```
+
+This will emit :start and :stop telemetry events with metadata such as the HTTP method, URL, and status code, which can be processed by your telemetry handler.
+
+For more information on `:telemetry`, visit the [official documentation](https://hexdocs.pm/telemetry/).
+
 ## Run tests
 
 ```sh

--- a/mix.exs
+++ b/mix.exs
@@ -54,7 +54,8 @@ defmodule Chargebeex.MixProject do
       {:credo, "~> 1.6", only: [:dev, :test], runtime: false},
       {:typed_struct, "~> 0.3.0"},
       {:dialyxir, ">= 0.0.0", only: [:dev], runtime: false},
-      {:exconstructor, "~> 1.2.7"}
+      {:exconstructor, "~> 1.2.7"},
+      {:telemetry, "~> 1.3"}
     ]
   end
 


### PR DESCRIPTION
This pull request introduces telemetry integration into the `Chargebeex` library, enabling users to monitor API calls via telemetry events. Key changes include modifications to the `Client` module to emit telemetry events for `get` and `post` requests and the addition of the `:telemetry` dependency in the project.

### Telemetry Integration:
* Updated the `get` and `post` methods to emit `:telemetry.span` events for API requests, capturing metadata such as HTTP method, URL, and status code.

### Dependency Update:
* Added the `:telemetry` library (`~> 1.3`) as a new dependency to support the telemetry integration.