### PR TITLE
[chargebeex] Add business_entity_id field and HTTP header support #PLA-1829

### DIFF
--- a/lib/chargebeex/client.ex
+++ b/lib/chargebeex/client.ex
@@ -101,8 +101,16 @@ defmodule Chargebeex.Client do
   defp default_headers(site, opts, verb \\ :get) do
     []
     |> add_user_details(opts)
+    |> add_business_entity(opts)
     |> add_basic_auth(site)
     |> add_content_type(verb)
+  end
+
+  defp add_business_entity(headers, opts) do
+    case Keyword.get(opts, :business_entity_id) do
+      nil -> headers
+      id -> [{"chargebee-business-entity-id", id} | headers]
+    end
   end
 
   defp add_user_details(headers, opts) do

--- a/lib/chargebeex/customer/customer.ex
+++ b/lib/chargebeex/customer/customer.ex
@@ -35,6 +35,7 @@ defmodule Chargebeex.Customer do
     field :vat_number_status, String.t()
     field :primary_payment_source_id, String.t()
     field :backup_payment_source_id, String.t()
+    field :business_entity_id, String.t()
     field :relationship, map()
     field :resources, map(), default: %{}
     field :custom_fields, map(), default: %{}

--- a/mix.exs
+++ b/mix.exs
@@ -16,7 +16,7 @@ defmodule Chargebeex.MixProject do
       },
       source_url: @source_url,
       homepage_url: @source_url,
-      version: "0.8.0",
+      version: "0.9.0",
       elixir: "~> 1.12",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
@@ -46,7 +46,7 @@ defmodule Chargebeex.MixProject do
   defp deps do
     [
       {:jason, "~> 1.0"},
-      {:hackney, "~> 4.0"},
+      {:hackney, "~> 1.18 or ~> 4.0"},
       {:plug, "~> 1.11"},
       {:ex_doc, "~> 0.23", only: :dev, runtime: false},
       {:hammox, "~> 0.5", only: :test},

--- a/test/chargebeex/builder/customer_test.exs
+++ b/test/chargebeex/builder/customer_test.exs
@@ -61,6 +61,7 @@ defmodule Chargebeex.Builder.CustomerTest do
       assert customer.vat_number_status == Map.get(params, "vat_number_status")
       assert customer.primary_payment_source_id == Map.get(params, "primary_payment_source_id")
       assert customer.backup_payment_source_id == Map.get(params, "backup_payment_source_id")
+      assert customer.business_entity_id == Map.get(params, "business_entity_id")
       assert customer.relationship == Map.get(params, "relationship")
     end
   end

--- a/test/chargebeex/client_test.exs
+++ b/test/chargebeex/client_test.exs
@@ -101,6 +101,33 @@ defmodule Chargebeex.ClientTest do
                  user_email_encoded: Base.encode64("user@test.com")
                )
     end
+
+    test "should add chargebee-business-entity-id header when business_entity_id is provided" do
+      expect(
+        Chargebeex.HTTPClientMock,
+        :get,
+        fn _url, _body, headers ->
+          assert {"chargebee-business-entity-id", "BE-FR-123"} in headers
+          {:ok, 200, [], Jason.encode!(%{})}
+        end
+      )
+
+      assert {:ok, 200, [], %{}} =
+               Client.get("/customers", %{}, business_entity_id: "BE-FR-123")
+    end
+
+    test "should not add chargebee-business-entity-id header when business_entity_id is absent" do
+      expect(
+        Chargebeex.HTTPClientMock,
+        :get,
+        fn _url, _body, headers ->
+          refute Enum.any?(headers, fn {k, _} -> k == "chargebee-business-entity-id" end)
+          {:ok, 200, [], Jason.encode!(%{})}
+        end
+      )
+
+      assert {:ok, 200, [], %{}} = Client.get("/customers", %{})
+    end
   end
 
   describe "post" do
@@ -163,6 +190,33 @@ defmodule Chargebeex.ClientTest do
                  user_email: "user@test.com",
                  user_email_encoded: Base.encode64("user@test.com")
                )
+    end
+
+    test "should add chargebee-business-entity-id header when business_entity_id is provided" do
+      expect(
+        Chargebeex.HTTPClientMock,
+        :post,
+        fn _url, _body, headers ->
+          assert {"chargebee-business-entity-id", "BE-UK-456"} in headers
+          {:ok, 200, [], Jason.encode!(%{})}
+        end
+      )
+
+      assert {:ok, 200, [], %{}} =
+               Client.post("/customers", %{}, business_entity_id: "BE-UK-456")
+    end
+
+    test "should not add chargebee-business-entity-id header when business_entity_id is absent" do
+      expect(
+        Chargebeex.HTTPClientMock,
+        :post,
+        fn _url, _body, headers ->
+          refute Enum.any?(headers, fn {k, _} -> k == "chargebee-business-entity-id" end)
+          {:ok, 200, [], Jason.encode!(%{})}
+        end
+      )
+
+      assert {:ok, 200, [], %{}} = Client.post("/customers", %{})
     end
   end
 end

--- a/test/support/fixtures/customer.ex
+++ b/test/support/fixtures/customer.ex
@@ -39,6 +39,7 @@ defmodule Chargebeex.Fixtures.Customer do
       "vat_number_validated_time": "1649946996",
       "primary_payment_source_id": "pm_198avhT6H0gYlLyG",
       "backup_payment_source_id": "pm_198avhT6H0gYlLyH",
+      "business_entity_id": "BE-FR-123",
       "relationship": {
         "invoice_owner_id": "BTcLQ4TK41I7DSPy",
         "parent_id": "BTcLQ4TK41I7DSPy",


### PR DESCRIPTION
## Summary

- Add `business_entity_id` field to `Chargebeex.Customer` typedstruct — ExConstructor auto-populates it from Chargebee webhook JSON, no changes needed in the builder or event handler chain
- Add `chargebee-business-entity-id` header support to `Chargebeex.Client` — emitted when `:business_entity_id` opt is passed to `get/3` or `post/3`, omitted when nil (backward-compatible)
- Relax hackney constraint to `~> 1.18 or ~> 4.0` for consumers still pinned to hackney 1.x
- Bump version 0.8.0 → 0.9.0

## Context

Prerequisite for PLA-1807 (fix `invoicing_entity` from webhook) and PLA-1816 (pass entity header on all outbound Chargebee calls) in [welcome-accounts MBE Phase 1](https://linear.app/wttj/project/billing-chargebee-mbe-multi-business-entity-856908c80565/overview).

## Test plan

- [ ] 166 existing tests still pass
- [ ] New builder test: `customer.business_entity_id` populated from fixture JSON
- [ ] New client tests: `chargebee-business-entity-id` header present when opt set (GET + POST)
- [ ] New client tests: header absent when opt not provided (GET + POST)

Relates to: #PLA-1829

🤖 Generated with [Claude Code](https://claude.com/claude-code)