### PR TITLE
chore: drop elixir 1.14.x from CI matrix, require ~> 1.15 #PLA-2267

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,16 +12,12 @@ jobs:
       fail-fast: false
       matrix:
         otp: ["26.x", "27.x", "28.x"]
-        elixir: ["1.14.x", "1.15.x", "1.16.x", "1.17.x", "1.18.x", "1.19.x"]
+        elixir: ["1.15.x", "1.16.x", "1.17.x", "1.18.x", "1.19.x"]
         exclude:
-          - elixir: 1.14.x
-            otp: 27.x
           - elixir: 1.15.x
             otp: 27.x
           - elixir: 1.16.x
             otp: 27.x
-          - elixir: 1.14.x
-            otp: 28.x
           - elixir: 1.15.x
             otp: 28.x
           - elixir: 1.16.x

--- a/mix.exs
+++ b/mix.exs
@@ -17,7 +17,7 @@ defmodule Chargebeex.MixProject do
       source_url: @source_url,
       homepage_url: @source_url,
       version: "0.9.0",
-      elixir: "~> 1.12",
+      elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
## Summary
- Elixir 1.14.x can no longer compile once `plug` is bumped past 1.19.x (see #224), since `plug` now requires Elixir `~> 1.15`.
- Drops the 1.14.x leg from the CI matrix and removes its now-redundant excludes.
- Bumps the `elixir` requirement in `mix.exs` from `~> 1.12` to `~> 1.15` to match.

## Test plan
- [x] `mix compile --warnings-as-errors` passes locally (Elixir 1.16.2 / OTP 26)
- [x] `mix test` passes locally (166 tests, 0 failures)
- [ ] CI matrix runs green on this PR without the 1.14.x leg
- [ ] Rebase/retest renovate PR #224 (plug bump) once this merges

Relates to: #PLA-2267