### PR TITLE
Inline release-please action instead of calling private reusable workflow #PLA-2286

### DIFF
--- a/.github/workflows/release_please.yml
+++ b/.github/workflows/release_please.yml
@@ -10,7 +10,17 @@ permissions:
 
 jobs:
   release-please:
-    uses: WTTJ/domain-platform/.github/workflows/common_release_please.yml@v1
+    runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
+    steps:
+      - uses: googleapis/release-please-action@v5
+        id: release
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json
 
   publish:
     needs: release-please


### PR DESCRIPTION
## Summary
- `release_please.yml` called a reusable workflow from the private `WTTJ/domain-platform` repo. GitHub Actions blocks a **public** repository from calling a reusable workflow defined in a **private** repo, regardless of the callee's org-wide "Access" setting.
- `chargebeex` is public (it publishes to Hex.pm), so every run of this workflow has failed with 0 jobs since it was introduced in #223.
- Fix: inline the `googleapis/release-please-action@v5` step directly (the same action the reusable workflow wraps), using the existing `release-please-config.json` / `.release-please-manifest.json`. The `publish` job is unchanged — it only consumed the `release_created`/`tag_name` outputs, which are preserved.

Actual GitHub error before this fix:
```
error parsing called workflow ".github/workflows/release_please.yml" ->
"WTTJ/domain-platform/.github/workflows/common_release_please.yml@v1" : workflow was not found.
```

## Test plan
- [x] `actionlint` reports no errors on the updated workflow
- [ ] Push to `main` triggers `release-please` job successfully (creates/updates the release PR)
- [ ] Merging a release PR triggers `publish` and publishes to Hex.pm correctly

Relates to: #PLA-2286